### PR TITLE
chore(package): fix all npm audit issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "fs-extra": "8.1.0",
     "ice-cap": "0.0.4",
     "marked": "0.7.0",
-    "minimist": "1.2.0",
+    "minimist": "1.2.5",
     "taffydb": "2.7.3"
   },
   "devDependencies": {


### PR DESCRIPTION
The remaining problem is in `esdoc-publish-html-plugin`. Not sure if it makes sense to wait for that one.

```
┌───────────────┬──────────────────────────────────────────────────────────────┐
│ Moderate      │ Regular Expression Denial of Service                         │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Package       │ marked                                                       │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Patched in    │ >=0.6.2                                                      │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Dependency of │ esdoc-standard-plugin [dev]                                  │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ Path          │ esdoc-standard-plugin > esdoc-publish-html-plugin > marked   │
├───────────────┼──────────────────────────────────────────────────────────────┤
│ More info     │ https://npmjs.com/advisories/812                             │
└───────────────┴──────────────────────────────────────────────────────────────┘
found 1 moderate severity vulnerability in 783 scanned packages
  1 vulnerability requires manual review. See the full report for details.
```

Besides `npm audit fix` I also ran `npm update` and had to jump a major version for `mocha` which in turn required updating the `engine` requirement in our `package.json`.

I successfully ran all tests and the build script but will check some more before removing the draft status. I don't want to break the thing with my first addition :smile: 