### PR TITLE
Run eslint only on Node 8 and later

### DIFF
--- a/script/test-ci.js
+++ b/script/test-ci.js
@@ -1,10 +1,5 @@
 #!/usr/bin/env node
 const sh = require('./sh');
 
-const NODE_MAJOR_VERSION = process.version.match(/^v(\d+)/)[1];
-
-if (NODE_MAJOR_VERSION >= 8) {
-  sh.exec('./script/eslint.js');
-}
 sh.exec('./script/test.js --coverage');
 sh.exec('./node_modules/.bin/codecov');

--- a/script/test-ci.js
+++ b/script/test-ci.js
@@ -1,6 +1,10 @@
 #!/usr/bin/env node
 const sh = require('./sh');
 
-sh.exec('./script/eslint.js');
+const NODE_MAJOR_VERSION = process.version.match(/^v(\d+)/)[1];
+
+if (NODE_MAJOR_VERSION >= 8) {
+  sh.exec('./script/eslint.js');
+}
 sh.exec('./script/test.js --coverage');
 sh.exec('./node_modules/.bin/codecov');

--- a/script/test.js
+++ b/script/test.js
@@ -1,7 +1,11 @@
 #!/usr/bin/env node
 const sh = require('./sh');
 
-sh.exec('./script/eslint.js');
+const NODE_MAJOR_VERSION = process.version.match(/^v(\d+)/)[1];
+
+if (parseInt(NODE_MAJOR_VERSION, 10) >= 8) {
+  sh.exec('./script/eslint.js');
+}
 
 sh.rm('./test/integration-test/out');
 const mochaOptions = [


### PR DESCRIPTION
This PR checks the major version of Node and runs eslint only if Node 8 or later is used.

Downgrading eslint is not an option es the moment and makes not much sense.