### PR TITLE
chore: update EditorConfig rules

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,3 +1,16 @@
-[*.js]
+# editorconfig.org
+
+root = true
+
+[*]
+charset = utf-8
+end_of_line = lf
+
+trim_trailing_whitespace = true
+insert_final_newline = true
+
 indent_style = space
 indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION
Not sure if charset and EOL are really needed. But, if we support Windows I guess we should include them.

I'm normally a tabs for indentation and spaces for alignment-guy but I do realize that two spaces are not only the de-facto standard but also the most forgiving style.

The only thing in this PR that I feel passionate about is the white-space trimming in Markdown files. Not trimming trailing white-spaces is something important and would allow us to remove some hacky `<br>`s from the manual :smiley: 