### PR TITLE
docs: remove hosting service from features

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ Please <a href="https://try.esdoc.org">try it out</a>!
 - Integrates test codes into documentation.
 - Integrates manual into documentation.
 - Parses ECMAScript proposals.
-- [ESDoc Hosting Service](https://doc.esdoc.org)
 
 # Users
 - [ESDoc](https://doc.esdoc.org/github.com/esdoc/esdoc/) (self-hosting &#x1F604;)


### PR DESCRIPTION
GitHub pages removed the need for a hosting service.